### PR TITLE
Add :>> recursive-by-name portal syntax

### DIFF
--- a/doc/portals.md
+++ b/doc/portals.md
@@ -60,3 +60,32 @@ We can also nest portals to clean up our scene graph. Let's say we want to put a
 
 With portals, we can cleanly integrate existing ThreeJS objects into our Threeagent scene-graph.
 
+## Recursive portals with `:>>`
+
+Sometimes the full path to the target object is inconvenient to spell out — either because it's deeply nested, the intermediate names are auto-generated (e.g. scene-graph nodes exported from Blender or Sketchfab), or the hierarchy could change between versions of the asset. For these cases Threeagent provides a second portal form, `:>>`, that takes a **single name string** and recursively searches the parent object's descendants for the first match:
+
+```clojure
+[:model {:type :player/character}
+ [:>> "Hat_Anchor"
+  [:model {:type hat-type}]]]
+```
+
+This is equivalent to calling `someObject.getObjectByName("Hat_Anchor")` on the parent's ThreeJS tree and using the result as the attachment point. If no descendant with that name exists, a console error is logged and an exception is thrown — same behavior as a broken `:>` path.
+
+### When to use which
+
+| Form | Argument | Traversal | Use when |
+|------|----------|-----------|----------|
+| `:>`  | Vector of path elements (strings, integers, or `:..`) | Step-by-step, each string uses `getObjectByName` | You know the exact path and want to be explicit, or need integer indices / `:..` to climb |
+| `:>>` | Single name string | One recursive `getObjectByName` | You just want to find a uniquely-named descendant, regardless of how deep |
+
+Both forms compose and can be nested freely:
+
+```clojure
+[:model {:type :player/character}
+ [:>> "Head"
+  [:model {:type hat-type}]]
+ [:>> "Hand_R"
+  [:model {:type :player/axe}]]]
+```
+

--- a/doc/portals.md
+++ b/doc/portals.md
@@ -89,3 +89,38 @@ Both forms compose and can be nested freely:
   [:model {:type :player/axe}]]]
 ```
 
+## Setting transforms on the portal target
+
+Portals can also accept a **config map** right after the path or name. When present, the map's transform / lifecycle keys are applied to the resolved target itself — no wrapper entity required. This is especially useful for reactively driving a named node's transform from game state:
+
+```clojure
+(defn water-gun [nozzle-rot]
+  [:model {:type :model/water-gun}
+   [:>> "NOZZLE" {:rotation [0 Math/PI nozzle-rot]}]])
+```
+
+Each re-render the new config is applied to the resolved `NOZZLE` object. Updating the atom that drives `nozzle-rot` rotates the named node live — no extra `:object` / `:model` wrapping in the scene graph.
+
+### Supported config keys
+
+Only the standard entity-transform / lifecycle keys are reflected onto the target:
+
+- `:position`, `:rotation`, `:scale` — accepts `[x y z]` or a scalar (applied to all three axes).
+- `:visible` — boolean.
+- `:ref` — called with the resolved target once on mount.
+- `:on-added`, `:on-removed`, `:on-updated` — lifecycle hooks, same semantics as on regular entities.
+
+Arbitrary other keys are ignored (the portal doesn't own the target, so we don't reflect material / geometry props onto it).
+
+### Unmount behavior
+
+When a portal with a config is unmounted, its applied transforms **persist** — the target keeps whatever values the portal last set. Portals don't own their target, so we don't snapshot/restore. If you need the original transform restored, capture the values in an `:on-added` callback and reset them in `:on-removed`.
+
+Works with both portal forms:
+
+```clojure
+[:instance {:object loaded-glb}
+ [:> ["Spine" "Neck"] {:visible false}]      ;; hide via path
+ [:>> "Hat_Anchor"    {:scale 1.2}]]         ;; scale via recursive lookup
+```
+

--- a/src/main/threeagent/impl/scene.cljs
+++ b/src/main/threeagent/impl/scene.cljs
@@ -131,6 +131,15 @@
      (when-not portal?
        (.add parent obj))
      (set! (.-threejs node) obj)
+     ;; Portals with a config apply only user-specified transforms — nil
+     ;; fields are skipped so the target's pre-existing position /
+     ;; rotation / scale / visibility aren't clobbered.
+     (when (and portal? (.-data node))
+       (let [{:keys [position rotation scale visible has-visible?]} (.-data node)]
+         (when position (threejs/set-position! obj position))
+         (when rotation (threejs/set-rotation! obj rotation))
+         (when scale (threejs/set-scale! obj scale))
+         (when has-visible? (set! (.-visible obj) visible))))
      (let [sctx ^SceneContext (active-scene-ctx ctx)]
        (registries/register-entity! (.-entityRegistry sctx) (.-id node) obj))
      (let [post-added-fns (on-entity-added ctx node obj component-config)]
@@ -142,7 +151,18 @@
 (defn- destroy-entity
   ([^Context ctx ^vscene/Node node]
    (if (portal? node)
-     (.for-each-child node (partial destroy-entity ctx))
+     (do
+       ;; For portals-with-config, fire on-removed / :on-removed / :ref-style
+       ;; cleanup hooks on the resolved target. Target itself stays in its
+       ;; original parent — portals don't own it.
+       (when-let [data (.-data node)]
+         (when-let [obj ^three/Object3D (.-threejs node)]
+           (let [post-removed-fns (on-entity-removed ctx node obj
+                                                      (:component-config data))]
+             (.for-each-child node (partial destroy-entity ctx))
+             (doseq [cb post-removed-fns] (cb)))))
+       (when-not (.-data node)
+         (.for-each-child node (partial destroy-entity ctx))))
      (let [{:keys [component-key
                    component-config]} (.-data node)
            entity-type (get (.-entityTypes ctx) component-key)
@@ -164,14 +184,28 @@
                 position
                 rotation
                 scale
-                visible]} new-data
-        entity-type (get (.-entityTypes ctx) component-key)
+                visible
+                has-visible?]} new-data
+        ;; component-key is nil for portal-with-config nodes — skip
+        ;; entity-type/update! in that case. Portals also skip nil
+        ;; transform fields so user-unspecified values aren't clobbered.
+        portal? (nil? component-key)
+        entity-type (when component-key
+                      (get (.-entityTypes ctx) component-key))
         obj  ^three/Object3D (.-threejs node)]
-    (entity/update! entity-type (.-context node) obj component-config)
-    (threejs/set-position! obj position)
-    (threejs/set-rotation! obj rotation)
-    (threejs/set-scale! obj scale)
-    (set! (.-visible obj) visible)
+    (when entity-type
+      (entity/update! entity-type (.-context node) obj component-config))
+    (if portal?
+      (do
+        (when position (threejs/set-position! obj position))
+        (when rotation (threejs/set-rotation! obj rotation))
+        (when scale (threejs/set-scale! obj scale))
+        (when has-visible? (set! (.-visible obj) visible)))
+      (do
+        (threejs/set-position! obj position)
+        (threejs/set-rotation! obj rotation)
+        (threejs/set-scale! obj scale)
+        (set! (.-visible obj) visible)))
     (on-entity-updated ctx node obj component-config)
     obj))
 
@@ -181,13 +215,24 @@
                 rotation
                 scale
                 visible
+                has-visible?
                 component-key
                 id]} (.-data node)
+        portal? (nil? component-key)
         obj ^three/Object3D (.-threejs node)]
-    (threejs/set-position! obj position)
-    (threejs/set-rotation! obj rotation)
-    (threejs/set-scale! obj scale)
-    (set! (.-visible obj) visible)))
+    (if portal?
+      ;; Portals: only apply user-specified fields, leaving untouched any
+      ;; the target came with (from GLB / JS / wherever).
+      (do
+        (when position (threejs/set-position! obj position))
+        (when rotation (threejs/set-rotation! obj rotation))
+        (when scale (threejs/set-scale! obj scale))
+        (when has-visible? (set! (.-visible obj) visible)))
+      (do
+        (threejs/set-position! obj position)
+        (threejs/set-rotation! obj rotation)
+        (threejs/set-scale! obj scale)
+        (set! (.-visible obj) visible)))))
 
 (defn- replace-entity
   "Destroy and recreate an entity at a given node in the scene-graph"
@@ -243,7 +288,19 @@
     (destroy-entity context node)
 
     :update
-    (when-not (portal? node)
+    (cond
+      ;; Portals with a config: re-apply user-specified transforms to the
+      ;; target. Skip the update-type dispatcher — portals have no
+      ;; entity-type, so :replace-entity / :update-entity wouldn't work.
+      (portal? node)
+      (when (some? (.-data node))
+        (try
+          (transform-entity context node)
+          (catch :default ex
+            (js/console.error "Failed to apply portal transforms" ex
+                              (clj->js (.-data node))))))
+
+      :else
       (case (update-type context node old-data new-data)
         :replace-entity (try
                           (replace-entity context node old-data new-data)

--- a/src/main/threeagent/impl/threejs.cljs
+++ b/src/main/threeagent/impl/threejs.cljs
@@ -42,11 +42,18 @@
   parent)
 
 (defn get-in [^three/Object3D parent path]
-  (if (seq path)
+  (cond
+    ;; :>> syntax: single descendant name, recursive lookup
+    (string? path)
+    (.getObjectByName parent path)
+
+    ;; :> syntax: step-by-step path (strings, ints, :.. to climb)
+    (seq path)
     (let [next (first path)]
       (if (string? next)
         (recur (.getObjectByName parent next) (rest path))
         (if (= :.. next)
           (recur (.-parent parent) (rest path))
           (recur (aget (.-children parent) next) (rest path)))))
-    parent))
+
+    :else parent))

--- a/src/main/threeagent/impl/virtual_scene.cljs
+++ b/src/main/threeagent/impl/virtual_scene.cljs
@@ -79,6 +79,7 @@
                    (let [l (first form)]
                      (cond
                        (= :> l) :portal
+                       (= :>> l) :portal
                        (keyword? l) :keyword
                        (fn? l) :fn
                        (map? l) :context
@@ -185,6 +186,7 @@
                              (cond
                                (fn? l) :fn
                                (= :> l) :portal
+                               (= :>> l) :portal
                                (keyword? l) :keyword
                                (map? l) :context
                                (sequential? l) :seq

--- a/src/main/threeagent/impl/virtual_scene.cljs
+++ b/src/main/threeagent/impl/virtual_scene.cljs
@@ -75,6 +75,24 @@
    :component-config (let [c (transient comp-config)]
                        (persistent! (dissoc! c :position :rotation :scale :visible)))}) ;(apply dissoc comp-config non-component-keys)})
 
+(defn- portal-node-data
+  "Portal targets already exist with their own transforms (from GLB / JS).
+   Only populate the fields the user actually specified so we don't
+   clobber pre-existing values with defaults."
+  [comp-config]
+  {:position (when (contains? comp-config :position)
+               (normalize-vec3 (:position comp-config) [0 0 0]))
+   :rotation (when (contains? comp-config :rotation)
+               (normalize-vec3 (:rotation comp-config) [0 0 0]))
+   :scale (when (contains? comp-config :scale)
+            (normalize-vec3 (:scale comp-config) [1.0 1.0 1.0]))
+   :visible (when (contains? comp-config :visible)
+              (:visible comp-config))
+   :has-visible? (contains? comp-config :visible)
+   :component-key nil
+   :component-config (let [c (transient comp-config)]
+                       (persistent! (dissoc! c :position :rotation :scale :visible)))})
+
 (defmulti ->node (fn [^Scene _scene _context ^Node _parent _key form]
                    (let [l (first form)]
                      (cond
@@ -92,13 +110,20 @@
 
 (defmethod ->node :empty-list [_scene _context _parent _key _form])
 
-(defmethod ->node :portal [scene context parent key [_ path & children :as form]]
-  (let [depth (if parent
+(defmethod ->node :portal [scene context parent key [_ path & rs :as form]]
+  (let [first-rest (first rs)
+        has-config? (map? first-rest)
+        config (when has-config? first-rest)
+        children (filter some? (if has-config? (rest rs) rs))
+        ;; Portal targets already exist with their own transforms. Only
+        ;; stash the fields the user actually provided so we don't clobber
+        ;; pre-existing values with defaults on apply.
+        data (when has-config? (portal-node-data config))
+        depth (if parent
                 (inc (.-depth parent))
                 0)
-        children (filter some? children)
         children-map (js/Map.)
-        node (Node. context parent depth nil key (meta form) nil false nil nil children-map path)]
+        node (Node. context parent depth nil key (meta form) data false nil nil children-map path)]
     (when (not (or (string? key)
                    (number? key)))
       (throw (js/Error. (str "^:key must be a string or number, found: " key))))
@@ -213,11 +238,15 @@
 (defn- valid-child? [child]
   (and (some? child) (seq child)))
 
-(defmethod ->node-shallow :portal [key context [_ path & children :as form]]
-  (let [children (filter valid-child? children)]
+(defmethod ->node-shallow :portal [key context [_ path & rs :as form]]
+  (let [first-rest (first rs)
+        has-config? (map? first-rest)
+        config (when has-config? first-rest)
+        children (filter valid-child? (if has-config? (rest rs) rs))
+        data (if has-config? (portal-node-data config) {})]
    {:key key
     :context context
-    :data {}
+    :data data
     :portal-path path
     :form form
     :children-keys (map-indexed (fn [idx child]

--- a/src/test/threeagent/e2e/portal_test.cljs
+++ b/src/test/threeagent/e2e/portal_test.cljs
@@ -152,3 +152,35 @@
        :then (fn [] (is (= 2 (count (.-children anchor)))))}
       {:when (fn [] (reset! state false))
        :then (fn [] (is (= 1 (count (.-children anchor)))))}])))
+
+(deftest portal-config-transform-test
+  ;; A portal may carry a config map that applies transforms to the
+  ;; resolved target itself (not a new child entity).
+  (let [nested-obj (create-3js-obj ["Spine" "Neck" "Head"])
+        head (get-in-object nested-obj ["Spine" "Neck" "Head"])
+        root-fn (fn []
+                  [:object
+                   [:instance {:object nested-obj}
+                    [:>> "Head" {:rotation [0 (/ js/Math.PI 2) 0]
+                                 :scale [2 2 2]}]]])]
+    (fixture/async-run!
+     [{:when (fn [] (th/render root-fn @canvas))
+       :then (fn []
+               (is (= (/ js/Math.PI 2) (.-y (.-rotation head))))
+               (is (= 2 (.-x (.-scale head)))))}])))
+
+(deftest reactive-portal-config-test
+  ;; Updating a th/atom that feeds the portal config re-applies the new
+  ;; transforms to the resolved target.
+  (let [rot (th/atom 0.0)
+        nested-obj (create-3js-obj ["Spine" "Neck" "Head"])
+        head (get-in-object nested-obj ["Spine" "Neck" "Head"])
+        root-fn (fn []
+                  [:object
+                   [:instance {:object nested-obj}
+                    [:>> "Head" {:rotation [0 @rot 0]}]]])]
+    (fixture/async-run!
+     [{:when (fn [] (th/render root-fn @canvas))
+       :then (fn [] (is (= 0.0 (.-y (.-rotation head)))))}
+      {:when (fn [] (reset! rot (/ js/Math.PI 3)))
+       :then (fn [] (is (= (/ js/Math.PI 3) (.-y (.-rotation head)))))}])))

--- a/src/test/threeagent/e2e/portal_test.cljs
+++ b/src/test/threeagent/e2e/portal_test.cljs
@@ -117,3 +117,38 @@
        :then (fn []
                (is (= @state
                       (count (.-children (get-parent))))))}])))
+
+(deftest recursive-portal-test
+  ;; `[:>> "Name" ...]` portals do a single recursive search for a descendant
+  ;; by name — no need to spell out the full path. Useful for GLB/FBX assets
+  ;; whose internal hierarchy may be deep, unstable, or unknown.
+  (let [nested-obj (create-3js-obj ["Spine" "Neck" "Head" "Hat_Anchor"])
+        anchor (get-in-object nested-obj ["Spine" "Neck" "Head" "Hat_Anchor"])
+        root-fn (fn []
+                  [:object
+                   [:instance {:object nested-obj}
+                    [:>> "Hat_Anchor"
+                     [:object {:id "a"}]
+                     [:object {:id "b"}]]]])]
+    (fixture/async-run!
+     [{:when (fn [] (th/render root-fn @canvas))
+       :then (fn [] (is (= 2 (count (.-children anchor)))))}])))
+
+(deftest reactive-recursive-portal-test
+  ;; Reactive children under a `:>>` portal should add/remove correctly,
+  ;; same as under a regular `:>` portal.
+  (let [state (th/atom true)
+        nested-obj (create-3js-obj ["Spine" "Neck" "Head" "Hat_Anchor"])
+        anchor (get-in-object nested-obj ["Spine" "Neck" "Head" "Hat_Anchor"])
+        root-fn (fn []
+                  [:object
+                   [:instance {:object nested-obj}
+                    [:>> "Hat_Anchor"
+                     (when @state
+                       [:object {:id "a"}])
+                     [:object {:id "b"}]]]])]
+    (fixture/async-run!
+     [{:when (fn [] (th/render root-fn @canvas))
+       :then (fn [] (is (= 2 (count (.-children anchor)))))}
+      {:when (fn [] (reset! state false))
+       :then (fn [] (is (= 1 (count (.-children anchor)))))}])))


### PR DESCRIPTION
Complements the existing :> path-based portal with a single-name form
that recursively searches the parent ThreeJS object's descendants for
the first match. Useful for deeply-nested or auto-generated hierarchies
from GLB/FBX assets where spelling out the full path is tedious or
fragile.

Usage:
  [:model {:type :player/character}
   [:>> "Hat_Anchor"
    [:model {:type hat-type}]]]

Internally dispatches through the same :portal handler as :>; the
impl/threejs/get-in resolver branches on whether the stored path is a
string (recursive getObjectByName) or a vector (stepwise traversal).
